### PR TITLE
jade compile add basedir

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 
 
 var jade = require('jade');
+var basedir = fis.project.getProjectPath();
 
 module.exports = function(content, file, conf){
   var data = {};
@@ -22,6 +23,7 @@ module.exports = function(content, file, conf){
       jade.filters[filter] = conf.filters[filter].bind(file);
     });
   }
+  conf.basedir = conf.basedir || basedir;
   var template = jade.compile( content, conf );
   template.dependencies.forEach(function(dep){
     file.cache.addDeps(dep);


### PR DESCRIPTION
basedir 添加默认配置，避免坑
影响到 include extends 使用绝对路径
